### PR TITLE
feat: take the screen size into account for ass

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   "license": "ISC",
   "dependencies": {
     "async": "^2.0.0-rc.3",
+    "body-parser": "^1.15.1",
     "chalk": "^1.1.3",
     "cli-clear": "^1.0.4",
-    "body-parser": "^1.15.1",
     "express": "^4.13.3",
     "minimist": "^1.2.0",
     "mplayer": "^2.1.0",
-    "prompt": "^1.0.0"
+    "prompt": "^1.0.0",
+    "screenres": "^2.0.0-rc1"
   },
   "devDependencies": {
     "eslint": "^2.9.0",

--- a/player.js
+++ b/player.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const sr = require('screenres')
 const argv = require('minimist')(process.argv.slice(2))
 const express = require('express')
 const bodyParser = require('body-parser')
@@ -33,10 +34,12 @@ if (argv.q || argv.quiet) {
 const allContents = JSON.parse(fs.readFileSync('./.data/allContents.json'))
 const playlist = []
 
+const screenResolution = sr.get()
 const mplayerOptions = {
   verbose: !!(argv.verbose || argv.v),
   debug: !!(argv.debug || argv.d),
-  args: '-ass -vo gl_nosw -fixed-vo',
+  args: '-ass -fixed-vo' +
+        ` -vf scale=${screenResolution[0]}:-3:::0.00:0.75,expand=:${screenResolution[1]},scale,ass`,
 }
 if (argv.novideo) {
   mplayerOptions.args += ' -vo null'


### PR DESCRIPTION
meaning that an old video upscaled will show correct ass styles
this needs to be tested on several config because it touches the
video filters heavily. I did had to deactivate the gl_nosw filter
to make it work (fortunately, the fixed-vo option still works for my
config)
