### PR TITLE
fix: no toggling nmplayer fullScreen on no next content

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -9,13 +9,12 @@ const getPlaylist = () => contents
 const setPlaylist = elements => (contents = [...elements])
 const addToPlaylist = content => contents.push(Object.assign({}, content))
 const randomizePlaylist = () => contents.sort(() => 0.5 - Math.random())
-const toggleFullScreen = () => mplayer.fullscreen()
 const pause = () => mplayer.pause()
 const getPlayingContent = () => playingContent
 const playNext = () => {
   if (isPlaying) return
   const content = contents.find(({ played }) => !played)
-  if (!content) return toggleFullScreen()
+  if (!content) return
   playingContent = content
   mplayer.openFile(content.path)
   isPlaying = true


### PR DESCRIPTION
Trying to a command to mplayer when it isn't launched crashes it (for me)

If the behaviour is different on multiple computers, we may need to modify nmplayer
