### PR TITLE
feat: take the screen size into account for ass

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "moment": "^2.13.0",
     "mplayer": "^2.1.0",
     "prompt": "^1.0.0",
+    "screenres": "^2.0.0-rc1",
     "ws": "^1.1.1"
   },
   "devDependencies": {

--- a/start.js
+++ b/start.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const argv = require('minimist')(process.argv.slice(2))
+const [width, height] = require('screenres').get()
 const player = require('./lib/player')
 const {
   setPlaylist,
@@ -31,7 +32,8 @@ const allContents = JSON.parse(fs.readFileSync('./.data/allContents.json'))
 const mplayerOptions = {
   verbose: !!(argv.verbose || argv.v),
   debug: !!(argv.debug || argv.d),
-  args: '-ass -vo gl_nosw -fixed-vo',
+  args: '-ass -fixed-vo' +
+        ` -vf scale=${width}:-3:::0.00:0.75,expand=:${height},scale,ass`,
 }
 if (argv.novideo) {
   mplayerOptions.args += ' -vo null'


### PR DESCRIPTION
meaning that an old video upscaled will show correct ass styles
this needs to be tested on several config because it touches the
video filters heavily. I did had to deactivate the gl_nosw filter
to make it work (fortunately, the fixed-vo option still works for my
config)
