### PR TITLE
feat: add a /ping route to allow for server discovery

### DIFF
--- a/server.js
+++ b/server.js
@@ -62,6 +62,8 @@ module.exports = ({ contents, port }) => {
     res.send({ message: 'Randomized' })
   })
 
+  app.get('/ping', (_, res) => res.send('pong'))
+
   server.on('request', app)
   server.listen(port, () => {
     console.log('Karakuri listening at')


### PR DESCRIPTION
We discussed about it in Signal.

If we have a /ping URL, we can test some ports from the mobile or desktop app to test if it is launched.

/ping > pong may not be enough though, what do you think?