### PR TITLE
fix playlist / playing content management

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -62,6 +62,9 @@ const playNext = () => {
     if (content) break
   }
   playingContent = content
+  if (content) {
+    contents = contents.filter(({ id }) => id !== playingContent.id)
+  }
   notifyPlaylist(getPlaylist())
 
   if (!content) return
@@ -71,9 +74,7 @@ const playNext = () => {
 const initPlayer = options => {
   mplayer = new Mplayer(options)
   mplayer.on('stop', () => {
-    contents = contents.filter(({ id }) => id !== playingContent.id)
     playingContent = null
-    notifyPlaylist(getPlaylist())
     playNext()
   })
 }

--- a/server.js
+++ b/server.js
@@ -35,8 +35,9 @@ module.exports = ({ contents, port }) => {
     const username = req.body.username || ''
     const content = contents.find(c => c.id === id)
     if (!content) return res.status(404).json({ message: 'Not found' })
-    const existingContent = getPlaylist().playlistContents.find(c => c.id === id)
-    if (existingContent) {
+    const { playlistContents, playingContent } = getPlaylist()
+    const existingContentInPlaylist = playlistContents.find(c => c.id === id)
+    if (existingContentInPlaylist || (playingContent || {}).id === id) {
       return res.send({ message: `${content.fileName} is already in playlist` })
     }
     addToPlaylist({ content, username })


### PR DESCRIPTION
* The whole point of  https://github.com/karakuri-js/karakuri-server/pull/45 was to stop sending the currently playing content as part of the playlist. Woops, it was still sent as part of the playlist, and only removed *after* being played
* Prevent re-adding the currently playing content in the playlist