### PR TITLE
Scrapper : Regroup subdirectories into the parent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,9 @@ yarn install
 ## Usage
 
 ```bash
+npm run scrap # Prepares karakuri-ready data from karaoke files
 npm start
 ```
+
+## Options
+Run `npm start -- --help` and `npm run scrap -- --help` to get a list of options.

--- a/localScrapper.js
+++ b/localScrapper.js
@@ -1,6 +1,10 @@
 const fs = require('fs')
 const async = require('async')
-const { kebabCase, omit } = require('lodash')
+const { kebabCase, last, omit } = require('lodash')
+const argv = require('minimist')(process.argv.slice(2))
+
+const karaokeDirectory = argv.directory || 'karaoke'
+const groupBySubdirectories = !!argv.useSubDirs
 
 const REGEX_WITH_LANGUAGE = /^(.+) - ([A-Z0-9 ]+) - (.+) ?(\(.{3}\))\.(.{2,4})$/
 const REGEX_WITHOUT_LANGUAGE = /^(.+) - ([A-Z0-9 ]+) - (.+)\.(.{2,4})$/
@@ -16,8 +20,15 @@ function getFileInfos(fileName, dirPath, stat) {
   let languageString
   let extension
 
-  const lastIndexOfSlash = dirPath.lastIndexOf('/')
-  const dirName = lastIndexOfSlash !== -1 ? dirPath.substr(lastIndexOfSlash + 1) : '.'
+  const directories = dirPath.split('/')
+  // Group by subdirectories : Take the name of the last directory (/karaoke/TEMP/Anime >> Anime)
+  // Group by top directory : Take the name of the topmost directory, excluding the base one :
+  //   /karaoke/TEMP/Anime >> TEMP
+  //   if anything is in the top directory, it will be indexed as such.
+  const dirName = groupBySubdirectories ?
+      last(directories) :
+      (directories[1] || directories[0])
+
   const fileNamePatterns = fileName.match(REGEX_WITH_LANGUAGE) || []
 
   if (fileNamePatterns.length) {
@@ -75,7 +86,7 @@ function createDataDir() {
 }
 
 const getFormattedContent = () => new Promise((resolve, reject) => {
-  getDirectoryContents('./karaoke', (err, contents) => {
+  getDirectoryContents(karaokeDirectory, (err, contents) => {
     if (err) return reject(err)
     const allContents = contents
       .filter(content => content.isVideo)

--- a/localScrapper.js
+++ b/localScrapper.js
@@ -3,6 +3,13 @@ const async = require('async')
 const { kebabCase, last, omit } = require('lodash')
 const argv = require('minimist')(process.argv.slice(2))
 
+if (argv.h || argv.help) {
+  console.log('usage: node localScrapper.js [options]\n')
+  console.log('  --directory      Base directory to scrap (default : ./karaoke)')
+  console.log('  --useSubDirs     Use sub directories instead of grouping by topmost directories')
+  process.exit(1)
+}
+
 const karaokeDirectory = argv.directory || 'karaoke'
 const groupBySubdirectories = !!argv.useSubDirs
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node start.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "scrap": "node localScrapper.js"
   },
   "author": "Hugo Agbonon",
   "license": "ISC",


### PR DESCRIPTION
Fixes https://github.com/karakuri-js/karakuri-server/issues/47

Also add a minimum tad of documentation as I've made the old behavior optional just in case