### PR TITLE
Remove async & promisify localScrapper, fixing crash on big directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "ass-parser": "^0.1.2",
-    "async": "^2.0.0-rc.3",
     "body-parser": "^1.15.1",
     "chalk": "^1.1.3",
     "cli-clear": "^1.0.4",


### PR DESCRIPTION
* Remove async.js
* Use promises where async was previously used. The current localScrapper crashed when `async.reduce` was used with too many elements.
* As a bonus, this clears the file of eslint errors.