### PR TITLE
ugly fix to prevent mpv spamming of events

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -106,8 +106,12 @@ const initPlayer = options => {
       : [...defaultOptions, ...options]
   )
   mpv.observeProperty('eof-reached', 13)
+
+  let lastStatusChanged = 0
   mpv.on('statuschange', status => {
-    if (status['eof-reached']) {
+    const now = Date.now()
+    if (status['eof-reached'] && now - lastStatusChanged > 1000) {
+      lastStatusChanged = now
       playingContent = null
       playNext()
     }


### PR DESCRIPTION
So yeah, not pretty but MPV is launching a LOT of events with the `eof-reached` status so `playNext()` was called in loop.

I know that this fix means that we'll have random glitches if we did too quickly next song (on mpv) but this should not happen too often.
But still, I want to understand MPV more to fix that correctly.